### PR TITLE
Fix: more spacing between the portfolio button and profile photo in responsive mode

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -19,7 +19,7 @@ const Home = () => {
 
                 <div>
                     <Link to='portfolio' smooth duration={500} 
-                    className='group text-white w-fit px-6 py-3 my-2 flex items-center
+                    className='group text-white w-fit px-6 py-3 my-5 flex items-center
                     rounded-md bg-gradient-to-r from-cyan-500 to-purple-800 cursor-pointer'>
                         Portfolio
                         <span className='group-hover:rotate-90 duration-300'>


### PR DESCRIPTION
Description:
Added more spacing between the portfolio button and profile photo in responsive mode

before:
![Screenshot 2024-02-29 111929](https://github.com/Rayleigh33/Portfolio/assets/103986489/6d1bd8a6-92ae-4bb2-8261-0a50d82c404b)

after:
![Screenshot 2024-02-29 115340](https://github.com/Rayleigh33/Portfolio/assets/103986489/509f5500-7c10-47f8-bda9-2b8b6021ba17)

Fixes #1